### PR TITLE
Fix "Notebook does not appear to be JSON" error

### DIFF
--- a/RES_project.ipynb
+++ b/RES_project.ipynb
@@ -616,8 +616,7 @@
     "\n",
     "C. Connect your country with, at least, two neighbour countries. You can assume that the capacities in the neighbours are fixed or cooptimase the whole system. You can also included fixed interconnection capacities or cooptimise them with the generators capacities. \n",
     "\n",
-    "F. Add other sectors such as heating \n",
-    "\n",
+    "F. Add other sectors such as heating"
    ]
   },
   {


### PR DESCRIPTION
Format error due to last comma.
The error was due to wrong ending of markdown source part where the last element also had a comma in the end but I also deleted the last two end-of-line codes.